### PR TITLE
add option to shift the undocked window by an x/y offset

### DIFF
--- a/Docking.js
+++ b/Docking.js
@@ -15,7 +15,9 @@ window.addEventListener('DOMContentLoaded', function() {
         //
         // dockingManager.init({
         //     spacing: 0,
-        //     range: 10
+        //     range: 10,
+        //     undockOffsetX: 15,
+        //     undockOffsetY: 15
         // });
 
         dockingManager.register(fin.desktop.Window.getCurrent(), false);


### PR DESCRIPTION
@wenjunche 

Adds an option to move the window on undock .. this seems like a reasonable thing to do for a generic window docking framework. Without any movement, it is not obvious that the window has successfully undocked .. also it is immediately in the snapping range, so on move, it will try to dock again straight away.

Inline comments as usual for any relevant specifics ..