### PR TITLE
update onload to use openfin events instead of bus channel

### DIFF
--- a/Docking.js
+++ b/Docking.js
@@ -25,8 +25,7 @@ window.addEventListener('DOMContentLoaded', function() {
 
         function createChildWindow() {
 
-            var dw = new fin.desktop.Window({
-
+            var windowOptions = {
                 name: 'child' + counter++,
                 url: 'childWindow.html',
                 defaultWidth: 200,
@@ -37,14 +36,18 @@ window.addEventListener('DOMContentLoaded', function() {
                 resize: true,
                 windowState: 'normal',
                 autoShow: true
+            };
 
-            }, function() {
+            var dw = new fin.desktop.Window(
+                windowOptions,
+                function() {
+                    dockingManager.register(dw);
+                }
+            );
 
-                dockingManager.register(dw);
-            });
-
-
-            return dw;
+            // To test using DockingWindow to create the OpenFin window
+            //
+            // dockingManager.register(windowOptions);
         }
 
         document.getElementById('createWindows').onclick = createChildWindow;

--- a/child.js
+++ b/child.js
@@ -21,14 +21,9 @@ function onDock(message) {
 
 }
 
-function updateDimentions() {
+function updateDimensions(bounds) {
 
-    var win = fin.desktop.Window.getCurrent();
-    win.getBounds(function(bounds) {
-
-        document.getElementById('dimentions').innerHTML = 'x: ' + bounds.left + ', y: ' + bounds.top + ', width: ' + bounds.width + ', height: ' + bounds.height;
-    });
-
+    document.getElementById('dimensions').innerHTML = 'x: ' + bounds.left + ', y: ' + bounds.top + ', width: ' + bounds.width + ', height: ' + bounds.height;
 }
 
 function onUnDock(message) {
@@ -50,7 +45,6 @@ fin.desktop.main(function() {
 
     document.getElementById('title').innerText = window.name;
 
-    setInterval(updateDimentions, 100);
     undockButton = document.getElementById('undockButton');
     undockButton.addEventListener('click', undock);
     enableUndock(false);
@@ -58,9 +52,7 @@ fin.desktop.main(function() {
     fin.desktop.InterApplicationBus.subscribe('*', 'window-docked', onDock);
     fin.desktop.InterApplicationBus.subscribe('*', 'window-undocked', onUnDock);
 
-    fin.desktop.InterApplicationBus.publish('window-load', {
-
-        windowName: window.name
-    });
-
+    var currentWindow = fin.desktop.Window.getCurrent();
+    currentWindow.getBounds(updateDimensions);
+    currentWindow.addEventListener('bounds-changing', updateDimensions);
 });

--- a/childWindow.html
+++ b/childWindow.html
@@ -67,7 +67,7 @@
       </table>
     </div>
     <div class="windowContent">
-      <div id="dimentions"> </div>
+      <div id="dimensions"> </div>
       <button id="undockButton">Undock</button>
     </div>
   </body>


### PR DESCRIPTION
@wenjunche 

Prior to this update - complete window initialization required a specific message to be published on a DM-specific channel 'window-load' .. with this change, the normal OpenFin window event handling can be used to trigger the finitialisation (adding window handlers, docking persistence etc.)
Note that this is still a 2-stage process, given the async nature of getBounds()

Inline comments to elaborate as necessary.