### PR TITLE
remove visibilitychange->minimize/restore handling

### DIFF
--- a/DockingManager.js
+++ b/DockingManager.js
@@ -593,7 +593,6 @@ var DockingManager = (function() {
 
         instance = this;
         this.createDelegates();
-        window.document.addEventListener('visibilitychange', this.onVisibilityChanged);
 
         getMonitorInfo();
     }
@@ -621,7 +620,6 @@ var DockingManager = (function() {
         this.onWindowRestore = this.onWindowRestore.bind(this);
         this.onWindowMinimize = this.onWindowMinimize.bind(this);
         this.dockAllSnappedWindows = this.dockAllSnappedWindows.bind(this);
-        this.onVisibilityChanged = this.onVisibilityChanged.bind(this);
     };
 
     DockingManager.prototype.undockWindow = function(windowName) {
@@ -680,18 +678,6 @@ var DockingManager = (function() {
                 removedDockableWindow.leaveGroup();
             }
         }
-    };
-
-    DockingManager.prototype.onVisibilityChanged = function() {
-
-        if (document.hidden) {
-
-            this.onWindowMinimize();
-        } else {
-
-            this.onWindowRestore();
-        }
-
     };
 
     DockingManager.prototype.onWindowClose = function(event) {


### PR DESCRIPTION
@wenjunche 

Small change to drop the visibilitychange handler on the main window (the one that initialises the DockingManager) .. in my experience, this only triggers occasionally, and when it does it is often at inopportune times like app shutdown (as commented elsewhere in the code, OpenFin windows get hide event before close) - if an app really needs specialised visibilitychange handling, then this can be easily added in app code, and the appropriate behaviour triggered through the DockingManager interface.