### PR TITLE
replace all foreach with for..of to avoid issues on transpilation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,14 +1,10 @@
 module.exports = {
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 2018,
+        "ecmaVersion": 2017,
         "sourceType": "module",
-        "ecmaFeatures": {
-            "impliedStrict": true
-        }
-    },
+     },
     "rules": {
-        "id-length": "off",
         "indent": [
             "error",
             4,
@@ -23,25 +19,12 @@ module.exports = {
                 "SwitchCase": 1
             }
         ],
-        "line-comment-position": "off",
         "max-lines": [
             "error", {
                 "max": 300,
                 "skipBlankLines": true,
                 "skipComments": true
             }
-        ],
-        "max-params": [
-            "error",
-            5
-        ],
-        "multiline-ternary": "off",
-        "no-await-in-loop": "warn",
-        "no-inline-comments": "off",
-        "no-ternary": "off",
-        "padded-blocks": [
-            "warn",
-            "never"
-        ],
+        ]
     }
 };

--- a/lib/DockingManager.js
+++ b/lib/DockingManager.js
@@ -34,7 +34,10 @@ export default class DockingManager {
 
     async initMonitorInfo() {
         const monitors = await requestMonitorInfo();
-        monitors.forEach(monitorInfo => this.monitors.push(monitorInfo));
+        for (const monitorInfo of monitors) {
+            // add to monitors array, rather than replacing the ref, in case window already initialised with ref
+            this.monitors.push(monitorInfo);
+        }
     }
 
     createDelegates() {
@@ -47,17 +50,6 @@ export default class DockingManager {
         this.onWindowRestore = this.onWindowRestore.bind(this);
         this.onWindowMinimize = this.onWindowMinimize.bind(this);
         this.undockWindow = this.undockWindow.bind(this);
-    }
-
-    undockWindow(windowName) {
-        const existingWindow = this.windows.find(window => window.name === windowName);
-        if (existingWindow) {
-            existingWindow.leaveDockingGroup(true);
-        }
-    }
-
-    undockAll() {
-        this.windows.forEach(window => window.leaveDockingGroup());
     }
 
     register(window, dockableToOthers) {
@@ -97,6 +89,19 @@ export default class DockingManager {
         }
     }
 
+    undockWindow(windowName) {
+        const existingWindow = DockingWindow.getWindowByName(this.windows, windowName);
+        if (existingWindow) {
+            existingWindow.leaveDockingGroup(true);
+        }
+    }
+
+    undockAll() {
+        for (const dockingWindow of this.windows) {
+            dockingWindow.leaveDockingGroup();
+        }
+    }
+
     onWindowClose(event) {
         this.unregister(event.target);
     }
@@ -106,21 +111,29 @@ export default class DockingManager {
             ? dockingWindow.group.children
             : [dockingWindow];
 
-        affectedWindows.forEach(window => window.openfinWindow.bringToFront());
+        for (const dockingWindow of affectedWindows) {
+            dockingWindow.openfinWindow.bringToFront();
+        }
     }
 
-    onWindowRestore(dockableWindow) {
-        if (!dockableWindow.group) {
+    onWindowRestore(dockingWindow) {
+        if (!dockingWindow.group) {
             return;
         }
-        dockableWindow.group.children.forEach(window => window.restore());
+
+        for (const groupedDockingWindow of dockingWindow.group.children) {
+            groupedDockingWindow.restore();
+        }
     }
 
-    onWindowMinimize(dockableWindow) {
-        if (!dockableWindow.group) {
+    onWindowMinimize(dockingWindow) {
+        if (!dockingWindow.group) {
             return;
         }
-        dockableWindow.group.children.forEach(window => window.minimize());
+
+        for (const groupedDockingWindow of dockingWindow.group.children) {
+            groupedDockingWindow.minimize();
+        }
     }
 
     onWindowMove(event) {
@@ -129,7 +142,6 @@ export default class DockingManager {
             return;
         }
 
-        // eslint-disable-next-line
         // TODO: refactor mutable event
         event.bounds.currentRange = currentWindow.currentRange;
 
@@ -148,7 +160,6 @@ export default class DockingManager {
 
             if (snapDirection) {
                 currentWindow.currentRange = currentWindow.range + 10;
-                // eslint-disable-next-line
                 // TODO: keep DOM events to handlers, or preferably contain within DW
                 const pos = this.getSnappedCoordinates(event, dockableWindow, snapDirection);
 
@@ -181,14 +192,13 @@ export default class DockingManager {
     }
 
     checkIfStillSnapped() {
-        Object.values(this.snappedWindows).forEach((snappedWindowInfo) => {
+        for (const snappedWindowInfo of Object.values(this.snappedWindows)) {
             if (snappedWindowInfo &&
                 !getSnapDirection(snappedWindowInfo[0], snappedWindowInfo[1]) &&
                 !getSnapDirection(snappedWindowInfo[1], snappedWindowInfo[0])) {
-                // currentWindow[1].setOpacity(1);
                 this.removeFromSnapList(snappedWindowInfo[0], snappedWindowInfo[1]);
             }
-        });
+        }
     }
 
     getSnappedCoordinates(event, window, position) {
@@ -258,10 +268,10 @@ export default class DockingManager {
     }
 
     dockAllSnappedWindows() {
-        Object.values(this.snappedWindows).forEach((snappedWindowInfo) => {
+        for (const snappedWindowInfo of Object.values(this.snappedWindows)) {
             this.removeFromSnapList(snappedWindowInfo[0], snappedWindowInfo[1]);
             this.addWindowToTheGroup(snappedWindowInfo[0], snappedWindowInfo[1]);
-        });
+        }
     }
 
     addWindowToTheGroup(snappedWindow, groupedWindow) {

--- a/lib/DockingWindow.js
+++ b/lib/DockingWindow.js
@@ -18,12 +18,8 @@ const dockingDefaults = {
 
 const openDockableWindows = {};
 
-function getWindowByName(windowList, windowName) {
-    return windowList.find(windowInList => windowInList === windowName);
-}
-
 async function regroup(persistenceService, allWindowsToRegroup, previousWindow, currentWindow, isNewGroup) {
-    // console.warn(`Regroup ${currentWindow.name}`);
+    // console.warn(`Regroup ${currentWindow.name}`); // eslint-disable-line no-undef, no-console
 
     const currentWindowIndex = allWindowsToRegroup.indexOf(currentWindow);
     if (currentWindowIndex === -1) {
@@ -51,14 +47,14 @@ async function regroup(persistenceService, allWindowsToRegroup, previousWindow, 
         }
     }
 
-    // console.warn(`handlePartners ${currentWindow.name}, ${partnerWindowNames}`);
-    partnerWindowNames.forEach(async function(partnerWindowName) {
-        const partnerWindow = getWindowByName(allWindowsToRegroup, partnerWindowName);
+    // console.warn(`handlePartners for ${currentWindow.name}: ${partnerWindowNames}`); // eslint-disable-line no-undef, no-console
+    for (const partnerWindowName of partnerWindowNames) {
+        const partnerWindow = DockingWindow.getWindowByName(allWindowsToRegroup, partnerWindowName);
         if (partnerWindow) {
             // we want to serialise these operations, so await in this loop is fine
             await regroup(persistenceService, allWindowsToRegroup, currentWindow, partnerWindow, isNewGroup);
         }
-    });
+    }
 }
 
 async function checkForSplitGroup(persistenceService, dockingGroup) {
@@ -118,6 +114,10 @@ export default class DockingWindow {
 
         this.currentRange = this.range;
         openDockableWindows[this.name] = this;
+    }
+
+    static getWindowByName(windowList, windowName) {
+        return windowList.find(windowInList => windowInList.name === windowName);
     }
 
     // DockingWindow API - external handlers
@@ -209,12 +209,10 @@ export default class DockingWindow {
             const potentialPartnerName = formerDockingPartners[i];
             const potentialPartnerWindow = openDockableWindows[potentialPartnerName];
 
-            /* eslint-disable */
             // TODO: push this stuff out into util class
             if (!potentialPartnerWindow ||
                 !getSnapDirection(this, potentialPartnerWindow) &&
                 !getSnapDirection(potentialPartnerWindow, this)) {
-                /* eslint-enable */
                 // garbage collection, essentially
                 // note, if a former partner has not been opened yet, then re-connecting
                 // that pair of windows will be handled by that window's persisted relationships

--- a/test/DockingWindow-test.js
+++ b/test/DockingWindow-test.js
@@ -1,0 +1,23 @@
+/* globals beforeEach, describe, it */
+import assert from 'assert';
+import DockingWindow from '../lib/DockingWindow';
+
+const DEFAULT_WINDOW_DOCKING_OPTIONS = {};
+
+describe('DockingWindow', () => {
+
+    describe('getWindowByName', () => {
+        let windows;
+
+        beforeEach(() => {
+            windows = [
+                new DockingWindow({name: 'bob'}, DEFAULT_WINDOW_DOCKING_OPTIONS)
+            ]
+        });
+
+        it('should retrieve the window if the name matches', () => {
+            assert.ok(DockingWindow.getWindowByName(windows, 'bob'));
+            assert.strictEqual(DockingWindow.getWindowByName(windows, 'dave'), undefined);
+        });
+    });
+});

--- a/test/OpenFinWrapper-test.js
+++ b/test/OpenFinWrapper-test.js
@@ -7,51 +7,53 @@ const FULLHD_WIDTH = 1920;
 const FULLHD_HEIGHT = 1080;
 const ERR_REQUEST_MONITOR_INFO = 'Something went wrong';
 
-describe('requestMonitorInfo', () => {
-    describe('default', () => {
-        let monitors;
-        beforeEach(async () => {
-            monitors = await requestMonitorInfo();
+describe('OpenFinWrapper', () => {
+    describe('requestMonitorInfo', () => {
+        describe('default', () => {
+            let monitors;
+            beforeEach(async () => {
+                monitors = await requestMonitorInfo();
+            });
+            it('returns an array with bounds for the single monitor', () => {
+                assert.equal(monitors.length, 1);
+            });
+            it('with Full HD dimensions', () => {
+                assert.equal(monitors[0].width, FULLHD_WIDTH);
+                assert.equal(monitors[0].height, FULLHD_HEIGHT);
+            });
         });
-        it('returns an array with bounds for the single monitor', () => {
-            assert.equal(monitors.length, 1);
+        describe('multi-monitor', () => {
+            let monitors;
+            beforeEach(async () => {
+                replaceStubOrValue('fin.desktop.System', 'getMonitorInfo', getMultiMonitorInfoStub);
+                monitors = await requestMonitorInfo();
+            });
+            it('returns an array containing the bounds of each monitor', () => {
+                assert.equal(monitors.length, 3);
+            });
+            it('each with Full HD dimensions', () => {
+                assert.equal(monitors[0].width, FULLHD_WIDTH);
+                assert.equal(monitors[1].width, FULLHD_WIDTH);
+                assert.equal(monitors[2].width, FULLHD_WIDTH);
+                assert.equal(monitors[0].height, FULLHD_HEIGHT);
+                assert.equal(monitors[1].height, FULLHD_HEIGHT);
+                assert.equal(monitors[2].height, FULLHD_HEIGHT);
+            });
+            afterEach(() => {
+                resetStubOrValue('fin.desktop.System', 'getMonitorInfo');
+            });
         });
-        it('with Full HD dimensions', () => {
-            assert.equal(monitors[0].width, FULLHD_WIDTH);
-            assert.equal(monitors[0].height, FULLHD_HEIGHT);
-        });
-    });
-    describe('multi-monitor', () => {
-        let monitors;
-        beforeEach(async () => {
-            replaceStubOrValue('fin.desktop.System', 'getMonitorInfo', getMultiMonitorInfoStub);
-            monitors = await requestMonitorInfo();
-        });
-        it('returns an array containing the bounds of each monitor', () => {
-            assert.equal(monitors.length, 3);
-        });
-        it('each with Full HD dimensions', () => {
-            assert.equal(monitors[0].width, FULLHD_WIDTH);
-            assert.equal(monitors[1].width, FULLHD_WIDTH);
-            assert.equal(monitors[2].width, FULLHD_WIDTH);
-            assert.equal(monitors[0].height, FULLHD_HEIGHT);
-            assert.equal(monitors[1].height, FULLHD_HEIGHT);
-            assert.equal(monitors[2].height, FULLHD_HEIGHT);
-        });
-        afterEach(() => {
-            resetStubOrValue('fin.desktop.System', 'getMonitorInfo');
-        });
-    });
-    describe('api error', () => {
-        beforeEach(async () => {
-            replaceStubOrValue('fin.desktop.System', 'getMonitorInfo', getMonitorErrorStub);
-        });
-        it('api call rejected with appropriate error message', async () => {
-            try {
-                await requestMonitorInfo();
-            } catch (rejectionError) {
-                assert.equal(rejectionError, ERR_REQUEST_MONITOR_INFO);
-            }
+        describe('api error', () => {
+            beforeEach(async () => {
+                replaceStubOrValue('fin.desktop.System', 'getMonitorInfo', getMonitorErrorStub);
+            });
+            it('api call rejected with appropriate error message', async () => {
+                try {
+                    await requestMonitorInfo();
+                } catch (rejectionError) {
+                    assert.equal(rejectionError, ERR_REQUEST_MONITOR_INFO);
+                }
+            });
         });
     });
 });

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -13,6 +13,9 @@ global.fin = {
         },
         System: {
             getMonitorInfo: getMonitorInfoStub
+        },
+        Window: function() {
+            this.getInfo = () => {}
         }
     }
 };


### PR DESCRIPTION
@wenjunche 

Main point of this is to replace unsound Array.forEach with for .. of style .. this is to avoid unpleasantness with await inside forEach when the code is transpiled.

Other small mods were fixing a little regression with window retrieval which had broken the split group logic, and some eslint cleanup