### PR TITLE
make moving and snapping opacities configurable

### DIFF
--- a/Docking.js
+++ b/Docking.js
@@ -13,10 +13,13 @@ function getDockingManager() {
     // Apply any of the following options
     // if you want to modify the docking parameters
     const dockingOptions = {
+        // range: 20,
         // spacing: 0,
-        // range: 10,
-        // undockOffsetX: 15,
-        // undockOffsetY: 15
+        // undockOffsetX: 25,
+        // undockOffsetY: 25,
+        // movingOpacity: 0.6,
+        // snappedMovingOpacity: 0.8,
+        // snappedTargetOpacity: 1
     };
 
     if (!dockingManager) {

--- a/lib/DockingManager.js
+++ b/lib/DockingManager.js
@@ -4,9 +4,15 @@ import DockingWindow from "./DockingWindow.js";
 import {getAppId, requestMonitorInfo} from "./OpenFinWrapper.js";
 import LocalStoragePersistence from "./LocalStoragePersistence.js";
 
-const DEFAULT_RANGE = 40;
-const DEFAULT_SPACING = 5;
-const DEFAULT_UNDOCK_OFFSET = 0;
+const dockingOptionDefaults = {
+    range: 40,
+    spacing: 5,
+    undockOffsetX: 0,
+    undockOffsetY: 0,
+    movingOpacity: 0.5,
+    snappedMovingOpacity: 0.5,
+    snappedTargetOpacity: 0.5
+};
 
 const DOCKING_MANAGER_NAMESPACE_PREFIX = 'dockingManager.';
 
@@ -20,16 +26,11 @@ export default class DockingManager {
         // temporary list of snappable window references
         this.snappedWindows = {};
         // default options
-        this.range = DEFAULT_RANGE;
-        this.spacing = DEFAULT_SPACING;
-        this.undockOffsetX = DEFAULT_UNDOCK_OFFSET;
-        this.undockOffsetY = DEFAULT_UNDOCK_OFFSET;
-
         this.persistenceService =
             new LocalStoragePersistence(DOCKING_MANAGER_NAMESPACE_PREFIX + getAppId());
         this.initMonitorInfo();
         this.createDelegates();
-        applyOptions(this, dockingOptions);
+        applyOptions(this, dockingOptions, dockingOptionDefaults);
     }
 
     async initMonitorInfo() {
@@ -61,6 +62,7 @@ export default class DockingManager {
             range: this.range,
             undockOffsetX: this.undockOffsetX,
             undockOffsetY: this.undockOffsetY,
+            movingOpacity: this.movingOpacity,
             dockableToOthers: dockableToOthers !== false,
             allMonitorBounds: this.monitors,
             persistenceService: this.persistenceService
@@ -256,14 +258,14 @@ export default class DockingManager {
             window1,
             window2
         ];
-        window1.setOpacity(0.5);
-        window2.setOpacity(0.5);
+        window1.setOpacity(this.snappedMovingOpacity);
+        window2.setOpacity(this.snappedTargetOpacity);
     }
 
     removeFromSnapList(window1, window2) {
         if (this.snappedWindows[window1.name + window2.name]) {
             Reflect.deleteProperty(this.snappedWindows, window1.name + window2.name);
-            window2.setOpacity(1);
+            window2.resetOpacity();
         }
     }
 
@@ -275,7 +277,7 @@ export default class DockingManager {
     }
 
     addWindowToTheGroup(snappedWindow, groupedWindow) {
-        snappedWindow.setOpacity(1);
+        snappedWindow.resetOpacity();
         snappedWindow.joinDockingGroup(groupedWindow);
     }
 }

--- a/lib/DockingUtil.js
+++ b/lib/DockingUtil.js
@@ -1,33 +1,41 @@
 
-export function applyOptions(instance, options) {
+function parsePositiveInt(option, defaultOption) {
+    if (!isNaN(Number.parseInt(option, 10)) && option >= 0) {
+        return option;
+    }
+    return defaultOption;
+}
+
+function parseOpacity(opacityOption, defaultOption) {
+    if (!isNaN(Number.parseFloat(opacityOption))
+        && opacityOption >= 0
+        && opacityOption <= 1) {
+        return opacityOption;
+    }
+    return defaultOption;
+}
+
+export function applyOptions(instance, options, defaults = {}) {
     if (!options) {
         return;
     }
-
     // 'range' is the distance between windows at which snapping applies
-    if (!isNaN(Number.parseInt(options.range, 10)) && options.range >= 0) {
-        instance.range = options.range;
-    }
-
+    instance.range = parsePositiveInt(options.range, defaults.range);
     // 'spacing' is the distance between windows when they become docked
-    if (!isNaN(Number.parseInt(options.spacing, 10)) && options.spacing >= 0) {
-        instance.spacing = options.spacing;
-    }
-
+    instance.spacing = parsePositiveInt(options.spacing, defaults.spacing);
     // 'undockOffsetX/Y' are offset values - they make the undocked window 'jump' a number of pixels
-    if (!isNaN(Number.parseInt(options.undockOffsetX, 10)) && options.undockOffsetX >= 0) {
-        instance.undockOffsetX = options.undockOffsetX;
-    }
-    if (!isNaN(Number.parseInt(options.undockOffsetY, 10)) && options.undockOffsetY >= 0) {
-        instance.undockOffsetY = options.undockOffsetY;
-    }
-
+    instance.undockOffsetX = parsePositiveInt(options.undockOffsetX, defaults.undockOffsetX);
+    instance.undockOffsetY = parsePositiveInt(options.undockOffsetY, defaults.undockOffsetY);
+    // opacities applied for 1) moving window, 2) snappedMovingWindow, 3) snappedTargetWindow
+    // Value from 0 (invisible) to 1.0 (fully opaque)
+    instance.movingOpacity = parseOpacity(options.movingOpacity, defaults.movingOpacity);
+    instance.snappedMovingOpacity = parseOpacity(options.snappedMovingOpacity, defaults.snappedMovingOpacity);
+    instance.snappedTargetOpacity = parseOpacity(options.snappedTargetOpacity, defaults.snappedTargetOpacity);
     // 'dockableToOthers' is a boolean which applies only to DockingWindow
-    if (options.dockableToOthers === true || options.dockableToOthers === false) {
-        instance.dockableToOthers = options.dockableToOthers;
-    }
+    instance.dockableToOthers = (options.dockableToOthers === true || options.dockableToOthers === false)
+        ? options.dockableToOthers
+        : defaults.dockableToOthers;
 }
-
 
 export function intersect(rectangle, targetRectangle) {
     // check right edge position of first window is to the left of left edge of second window, and so on ..

--- a/lib/DockingWindow.js
+++ b/lib/DockingWindow.js
@@ -13,7 +13,8 @@ const dockingDefaults = {
     range: 40,
     undockOffsetX: 0,
     undockOffsetY: 0,
-    dockableToOthers: true,
+    movingOpacity: 0.5,
+    dockableToOthers: true
 };
 
 const openDockableWindows = {};
@@ -93,7 +94,7 @@ export default class DockingWindow {
         this.allMonitorBounds = dockingOptions.allMonitorBounds;
         this.persistenceService = dockingOptions.persistenceService;
         // simple property defaults
-        this.opacity = 1;
+        this.originalOpacity = 1;
         this.acceptDockingConnection = true;
         this.minimized = false;
         this.group = null;
@@ -105,8 +106,8 @@ export default class DockingWindow {
         }
 
         // OpenFin Window is definitely created now, but may not be fully initialized
-        this.openfinWindow.getInfo(
-            () => this.onWindowInitialized(),
+        this.openfinWindow.getOptions(
+            this.onWindowOptions,
             () => this.openfinWindow.addEventListener('initialized', () => this.onWindowInitialized())
         );
 
@@ -143,15 +144,14 @@ export default class DockingWindow {
     }
 
     setOpacity(value) {
-        if (this.opacity === value) {
-            return;
-        }
-        this.opacity = value;
-        this.openfinWindow.animate({
-            opacity: {
-                opacity: value,
-                duration: 0
-            }
+        this.openfinWindow.updateOptions({
+            opacity: value
+        });
+    }
+
+    resetOpacity() {
+        this.openfinWindow.updateOptions({
+            opacity: this.originalOpacity
         });
     }
 
@@ -170,10 +170,9 @@ export default class DockingWindow {
     }
 
     // bound functions for openfin event handlers
-    // (use arrow funcs when possible, and remove this function)
+    // (use class property arrow funcs when possible, and remove this function)
     createDelegates() {
-        // this.onMove = this.onMove.bind(this);
-        // this.onMoveComplete = this.onMoved.bind(this);
+        this.onWindowOptions = this.onWindowOptions.bind(this);
         this.completeInitialization = this.completeInitialization.bind(this);
         this.onBoundsChanging = this.onBoundsChanging.bind(this);
         this.onBoundsChanged = this.onBoundsChanged.bind(this);
@@ -184,6 +183,12 @@ export default class DockingWindow {
         this.onMinimized = this.onMinimized.bind(this);
         this.onRestored = this.onRestored.bind(this);
         this.onGroupChanged = this.onGroupChanged.bind(this);
+    }
+
+    onWindowOptions(windowOptions) {
+        // make note of opacity for this existing window, set as original
+        this.originalOpacity = windowOptions.opacity;
+        this.onWindowInitialized();
     }
 
     onWindowInitialized() {
@@ -251,7 +256,7 @@ export default class DockingWindow {
         }
 
         if (!this.group) {
-            this.setOpacity(0.5);
+            this.setOpacity(this.movingOpacity);
         }
 
         this.moveTo(bounds.left, bounds.top, bounds.width, bounds.height);
@@ -268,7 +273,7 @@ export default class DockingWindow {
     }
 
     onBoundsChanged() {
-        this.setOpacity(1);
+        this.resetOpacity();
         this.onMoveComplete({target: this});
     }
 

--- a/test/DockingManager-init-test.js
+++ b/test/DockingManager-init-test.js
@@ -2,57 +2,72 @@
 import assert from 'assert';
 import DockingManager from '../lib/DockingManager.js';
 
-describe('DockingManager', () => {
+describe('DockingManager', function() {
     let dockingManager;
 
-    describe('init', () => {
-        describe('full', () => {
-            beforeEach(() => {
+    describe('init', function() {
+        describe('full', function() {
+            beforeEach(function() {
                 dockingManager = new DockingManager({
-                    spacing: 25,
                     range: 35,
+                    spacing: 0,
                     undockOffsetX: 5,
-                    undockOffsetY: 5
+                    undockOffsetY: 5,
+                    movingOpacity: 0.6,
+                    snappedMovingOpacity: 0.8,
+                    snappedTargetOpacity: 1
                 });
             });
 
-            it('should set initial values correctly', () => {
-                assert.equal(dockingManager.spacing, 25);
+            it('should set properties from stated values only', function() {
                 assert.equal(dockingManager.range, 35);
+                assert.equal(dockingManager.spacing, 0);
                 assert.equal(dockingManager.undockOffsetX, 5);
                 assert.equal(dockingManager.undockOffsetY, 5);
+                assert.equal(dockingManager.movingOpacity, 0.6);
+                assert.equal(dockingManager.snappedMovingOpacity, 0.8);
+                assert.equal(dockingManager.snappedTargetOpacity, 1);
             });
         });
 
-        describe('partial', () => {
-            beforeEach(() => {
+        describe('partial / valid', function() {
+            beforeEach(function() {
                 dockingManager = new DockingManager({
-                    spacing: 20,
-                    range: 30
+                    range: 30,
+                    spacing: 20
                 });
             });
 
-            it('should set initial values correctly', () => {
-                assert.equal(dockingManager.spacing, 20);
+            it('should set the stated values and set other values from defaults', function() {
                 assert.equal(dockingManager.range, 30);
+                assert.equal(dockingManager.spacing, 20);
                 assert.equal(dockingManager.undockOffsetX, 0);
                 assert.equal(dockingManager.undockOffsetY, 0);
+                assert.equal(dockingManager.movingOpacity, 0.5);
+                assert.equal(dockingManager.snappedMovingOpacity, 0.5);
+                assert.equal(dockingManager.snappedTargetOpacity, 0.5);
             });
         });
 
-        describe('invalid', () => {
-            beforeEach(() => {
+        describe('partial / all invalid', function() {
+            beforeEach(function() {
                 dockingManager = new DockingManager({
+                    range: -5,
                     spacing: 'BIG',
-                    range: -5
+                    movingOpacity: -1,
+                    snappedMovingOpacity: 100,
+                    snappedTargetOpacity: 'bob'
                 });
             });
 
-            it('should set initial values correctly', () => {
-                assert.equal(dockingManager.spacing, 5);
+            it('should set all values from defaults', function() {
                 assert.equal(dockingManager.range, 40);
+                assert.equal(dockingManager.spacing, 5);
                 assert.equal(dockingManager.undockOffsetX, 0);
                 assert.equal(dockingManager.undockOffsetY, 0);
+                assert.equal(dockingManager.movingOpacity, 0.5);
+                assert.equal(dockingManager.snappedMovingOpacity, 0.5);
+                assert.equal(dockingManager.snappedTargetOpacity, 0.5);
             });
         });
     });

--- a/test/DockingUtil-test.js
+++ b/test/DockingUtil-test.js
@@ -2,10 +2,10 @@
 import assert from 'assert';
 import { intersect } from '../lib/DockingUtil';
 
-describe('DockingUtil', () => {
-    describe('intersect', () => {
-        describe('when pairs of rectangles are tested', () => {
-            it('should correctly assess whether they overlap', () => {
+describe('DockingUtil', function() {
+    describe('intersect', function() {
+        describe('when pairs of rectangles are tested', function() {
+            it('should correctly assess whether they overlap', function() {
                 assert.ok(intersect(overlappingRect1, overlappingRect2));
             });
         });

--- a/test/DockingWindow-test.js
+++ b/test/DockingWindow-test.js
@@ -4,18 +4,18 @@ import DockingWindow from '../lib/DockingWindow';
 
 const DEFAULT_WINDOW_DOCKING_OPTIONS = {};
 
-describe('DockingWindow', () => {
+describe('DockingWindow', function() {
 
-    describe('getWindowByName', () => {
+    describe('getWindowByName', function() {
         let windows;
 
-        beforeEach(() => {
+        beforeEach(function() {
             windows = [
                 new DockingWindow({name: 'bob'}, DEFAULT_WINDOW_DOCKING_OPTIONS)
             ]
         });
 
-        it('should retrieve the window if the name matches', () => {
+        it('should retrieve the window if the name matches', function() {
             assert.ok(DockingWindow.getWindowByName(windows, 'bob'));
             assert.strictEqual(DockingWindow.getWindowByName(windows, 'dave'), undefined);
         });

--- a/test/OpenFinWrapper-test.js
+++ b/test/OpenFinWrapper-test.js
@@ -7,31 +7,31 @@ const FULLHD_WIDTH = 1920;
 const FULLHD_HEIGHT = 1080;
 const ERR_REQUEST_MONITOR_INFO = 'Something went wrong';
 
-describe('OpenFinWrapper', () => {
-    describe('requestMonitorInfo', () => {
-        describe('default', () => {
+describe('OpenFinWrapper', function() {
+    describe('requestMonitorInfo', function() {
+        describe('default', function() {
             let monitors;
-            beforeEach(async () => {
+            beforeEach(async function() {
                 monitors = await requestMonitorInfo();
             });
-            it('returns an array with bounds for the single monitor', () => {
+            it('returns an array with bounds for the single monitor', function() {
                 assert.equal(monitors.length, 1);
             });
-            it('with Full HD dimensions', () => {
+            it('with Full HD dimensions', function() {
                 assert.equal(monitors[0].width, FULLHD_WIDTH);
                 assert.equal(monitors[0].height, FULLHD_HEIGHT);
             });
         });
-        describe('multi-monitor', () => {
+        describe('multi-monitor', function() {
             let monitors;
-            beforeEach(async () => {
+            beforeEach(async function() {
                 replaceStubOrValue('fin.desktop.System', 'getMonitorInfo', getMultiMonitorInfoStub);
                 monitors = await requestMonitorInfo();
             });
-            it('returns an array containing the bounds of each monitor', () => {
+            it('returns an array containing the bounds of each monitor', function() {
                 assert.equal(monitors.length, 3);
             });
-            it('each with Full HD dimensions', () => {
+            it('each with Full HD dimensions', function() {
                 assert.equal(monitors[0].width, FULLHD_WIDTH);
                 assert.equal(monitors[1].width, FULLHD_WIDTH);
                 assert.equal(monitors[2].width, FULLHD_WIDTH);
@@ -39,15 +39,15 @@ describe('OpenFinWrapper', () => {
                 assert.equal(monitors[1].height, FULLHD_HEIGHT);
                 assert.equal(monitors[2].height, FULLHD_HEIGHT);
             });
-            afterEach(() => {
+            afterEach(function() {
                 resetStubOrValue('fin.desktop.System', 'getMonitorInfo');
             });
         });
-        describe('api error', () => {
-            beforeEach(async () => {
+        describe('api error', function() {
+            beforeEach(async function() {
                 replaceStubOrValue('fin.desktop.System', 'getMonitorInfo', getMonitorErrorStub);
             });
-            it('api call rejected with appropriate error message', async () => {
+            it('api call rejected with appropriate error message', async function() {
                 try {
                     await requestMonitorInfo();
                 } catch (rejectionError) {

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -15,7 +15,7 @@ global.fin = {
             getMonitorInfo: getMonitorInfoStub
         },
         Window: function() {
-            this.getInfo = () => {}
+            this.getOptions = () => {}
         }
     }
 };


### PR DESCRIPTION
@wenjunche 

added some config properties to adjust opacities for a) a single ungrouped window when moving, b) when that window is snapped to another (single or in a group), and c) the window it is snapped to

also updated all mocha tests to use std functions, per https://mochajs.org/#arrow-functions
