### PR TITLE
fix window focus issues on snapping and when grouped

### DIFF
--- a/Docking.js
+++ b/Docking.js
@@ -57,6 +57,7 @@ function createAndRegister(windowNameSuffix) {
         defaultTop: (screen.availHeight - 200) / 2,
         defaultLeft: (screen.availWidth - 150) / 2,
         frame: false,
+        shadow: true,
         autoShow: true
     };
 
@@ -82,14 +83,14 @@ function onOpenFinReady() {
     document.getElementById('createWindows').onclick = () => { createAndRegister(++counter); };
 
     // convenience to restore up to 10 docked child windows from previous persistance
-    for (let tempCounter = 0; tempCounter < 10; tempCounter++) {
-        const DOCKING_MANAGER_NAMESPACE_PREFIX = 'dockingManager.';
-        const windowStorageKey = `${DOCKING_MANAGER_NAMESPACE_PREFIX}${fin.desktop.Application.getCurrent().uuid}.child${tempCounter}`;
-        if (localStorage.getItem(windowStorageKey)) {
-            createAndRegister(tempCounter);
-            counter = tempCounter;
-        }
-    }
+    // for (let tempCounter = 0; tempCounter < 10; tempCounter++) {
+    //     const DOCKING_MANAGER_NAMESPACE_PREFIX = 'dockingManager.';
+    //     const windowStorageKey = `${DOCKING_MANAGER_NAMESPACE_PREFIX}${fin.desktop.Application.getCurrent().uuid}.child${tempCounter}`;
+    //     if (localStorage.getItem(windowStorageKey)) {
+    //         createAndRegister(tempCounter);
+    //         counter = tempCounter;
+    //     }
+    // }
 
     fin.desktop.InterApplicationBus.subscribe('*', 'window-docked', function(message) {
         console.log('window-docked subscription: ' + message.windowName + ' joined group');

--- a/lib/DockingManager.js
+++ b/lib/DockingManager.js
@@ -109,13 +109,12 @@ export default class DockingManager {
     }
 
     bringWindowOrGroupToFront(dockingWindow) {
-        const affectedWindows = dockingWindow.group
-            ? dockingWindow.group.children
-            : [dockingWindow];
-
-        for (const dockingWindow of affectedWindows) {
-            dockingWindow.openfinWindow.bringToFront();
+        if (dockingWindow.group) {
+            for (const groupDockingWindow of dockingWindow.group.children) {
+                groupDockingWindow.openfinWindow.bringToFront();
+            }
         }
+        dockingWindow.openfinWindow.bringToFront();
     }
 
     onWindowRestore(dockingWindow) {
@@ -166,6 +165,7 @@ export default class DockingManager {
                 const pos = this.getSnappedCoordinates(event, dockableWindow, snapDirection);
 
                 this.bringWindowOrGroupToFront(dockableWindow);
+                currentWindow.openfinWindow.bringToFront();
 
                 if (!position.x) {
                     position.x = pos.x;


### PR DESCRIPTION
@wenjunche 
primary window can end up being un-focused when selected in group, or when moving and snapping to potential partner due to simple previous 'focus all in group' logic ..