### PR TITLE
add toggle for onclose -> unregister, to help with app close scenarios

### DIFF
--- a/lib/DockingManager.js
+++ b/lib/DockingManager.js
@@ -12,7 +12,8 @@ const dockingOptionDefaults = {
     undockOffsetY: 0,
     movingOpacity: 0.5,
     snappedMovingOpacity: 0.5,
-    snappedTargetOpacity: 0.5
+    snappedTargetOpacity: 0.5,
+    unregisterOnClose: true
 };
 
 const DOCKING_MANAGER_NAMESPACE_PREFIX = 'dockingManager.';
@@ -68,11 +69,13 @@ export default class DockingManager {
         const dockingWindow = new DockingWindow(window, dockingOptions);
         dockingWindow.onMove = this.onWindowMove;
         dockingWindow.onMoveComplete = this.dockAllSnappedWindows;
-        dockingWindow.onClose = this.onWindowClose;
         dockingWindow.onFocus = this.bringWindowOrGroupToFront;
         dockingWindow.onRestore = this.onWindowRestore;
         dockingWindow.onMinimize = this.onWindowMinimize;
         dockingWindow.onLeaveGroup = this.undockWindow;
+        if (this.unregisterOnClose) {
+            dockingWindow.onClose = this.onWindowClose;
+        }
         this.windows.push(dockingWindow);
     }
 

--- a/lib/OptionsParser.js
+++ b/lib/OptionsParser.js
@@ -35,4 +35,8 @@ export function applyOptions(instance, options, defaults = {}) {
     instance.dockableToOthers = (options.dockableToOthers === true || options.dockableToOthers === false)
         ? options.dockableToOthers
         : defaults.dockableToOthers;
+    // 'unregisterOnClose' is a boolean which toggles automatic unregistration on close of a DockingWindow
+    instance.unregisterOnClose = (options.unregisterOnClose === true || options.unregisterOnClose === false)
+        ? options.unregisterOnClose
+        : defaults.unregisterOnClose;
 }

--- a/local-es6.json
+++ b/local-es6.json
@@ -15,7 +15,7 @@
     },
     "runtime": {
         "arguments": "--force-device-scale-factor=1",
-        "version": "9.61.31.45"
+        "version": "9.61.32.15"
     },
     "shortcut": {
         "company": "OpenFin",

--- a/test/lib/DockingWindow-test.js
+++ b/test/lib/DockingWindow-test.js
@@ -4,32 +4,41 @@ import assert from 'assert';
 import DockingWindow from '../../lib/DockingWindow';
 import * as sinon from "sinon";
 
-const DEFAULT_WINDOW_DOCKING_OPTIONS = {};
+const FAKE_DOCKING_OPTIONS = {};
 
 describe('DockingWindow', function() {
     let dockingWindow;
-    let getOptionsStub;
-    let getBoundsFake, addEventListenerFake, disableFrameFake;
+    let getOptionsStub, getBoundsStub;
+    let addEventListenerFake, disableFrameFake, persistenceServiceRetrieveFake;
     let updateOptionsSpy;
+    const ORIG_OPACITY = 0.8;
 
     beforeEach(function () {
         getOptionsStub = sinon.stub();
+        getOptionsStub.callsArgWith(0, {
+            opacity: ORIG_OPACITY
+        });
         fin.desktop.Window.prototype.getOptions = getOptionsStub;
-        getBoundsFake = sinon.fake();
-        fin.desktop.Window.prototype.getBounds = getBoundsFake;
+        getBoundsStub = sinon.stub();
+        getBoundsStub.callsArgWith(0, {x: 0, y: 0, width: 100, height: 100});
+        fin.desktop.Window.prototype.getBounds = getBoundsStub;
         disableFrameFake = sinon.fake();
         fin.desktop.Window.prototype.disableFrame = disableFrameFake;
         addEventListenerFake = sinon.fake();
         fin.desktop.Window.prototype.addEventListener = addEventListenerFake;
         updateOptionsSpy = sinon.spy();
         fin.desktop.Window.prototype.updateOptions = updateOptionsSpy;
+        persistenceServiceRetrieveFake = sinon.fake.returns([]);
+        FAKE_DOCKING_OPTIONS.persistenceService = {
+            retrieveRelationshipsFor: persistenceServiceRetrieveFake
+        };
     });
 
     describe('getWindowByName', function() {
         let windows;
 
         beforeEach(function() {
-            dockingWindow = new DockingWindow({name: 'bob'}, DEFAULT_WINDOW_DOCKING_OPTIONS);
+            dockingWindow = new DockingWindow({name: 'bob'}, FAKE_DOCKING_OPTIONS);
             windows = [ dockingWindow ];
         });
 
@@ -40,14 +49,10 @@ describe('DockingWindow', function() {
     });
 
     describe('opacity', function() {
-        const ORIG_OPACITY = 0.8;
         const NEW_OPACITY = 0.4;
 
         beforeEach(function() {
-            getOptionsStub.callsArgWith(0, {
-                opacity: ORIG_OPACITY
-            });
-            dockingWindow = new DockingWindow({name: 'bob'}, DEFAULT_WINDOW_DOCKING_OPTIONS);
+            dockingWindow = new DockingWindow({name: 'bob'}, FAKE_DOCKING_OPTIONS);
         });
 
         describe('when the opacity value of a window is modified', function() {


### PR DESCRIPTION
@wenjunche - new option for win close handling in DM - if we always unregister on close of a window, then sometimes at app close, we can lose all our docking persistence.

Tidied up DW test so more of the init code is exercised.

Move to latest v9 runtime.